### PR TITLE
enhancement - allow different subjects for caseworker and customer

### DIFF
--- a/lib/email-service.js
+++ b/lib/email-service.js
@@ -24,6 +24,12 @@ module.exports = class EmailService {
     this.customerEmail = options.customerEmail;
     this.caseworkerEmail = options.caseworker;
     this.subject = options.subject;
+    if (typeof this.subject === 'string') {
+      this.subject = {
+        customer: this.subject,
+        caseworker: this.subject
+      };
+    }
     this.intro = {
       customer: options.customerIntro,
       caseworker: options.caseworkerIntro
@@ -52,7 +58,7 @@ module.exports = class EmailService {
         this._renderTemplate('formatted', recipient, data),
         this._renderTemplate('raw', recipient, data),
       ]).then(values => {
-        this.emailer.sendEmail(to, this.subject, values, (err, info) => {
+        this.emailer.sendEmail(to, this.subject[recipient], values, (err, info) => {
           if (err) {
             // eslint-disable-next-line no-console
             console.error('Error sending email');

--- a/test/integration/index-spec.js
+++ b/test/integration/index-spec.js
@@ -16,33 +16,30 @@ describe('HOF Emailer', () => {
     emailService = new EmailService(Object.assign({}, config, {data}));
   });
 
-  it('sends emails', done => {
+  it('sends emails', () =>
     emailService.sendEmails().then(info => {
       info[0].response.should.be.an.instanceOf(Buffer);
       info[1].response.should.be.an.instanceOf(Buffer);
-      done();
-    });
-  });
+    })
+  );
 
-  it('contains data passed', done => {
+  it('contains data passed', () =>
     emailService.sendEmails().then(info => {
       const response = info[0].response.toString('utf-8');
 
       response.should.contain('123 Example Street, Croydon');
       response.should.contain('Some text to find from within the email');
-      done();
-    });
-  });
+    })
+  );
 
   describe('Template Rendering', () => {
     describe('Raw Template', () => {
       let output;
-      beforeEach(done => {
+      beforeEach(() =>
         emailService._renderTemplate('raw', 'customer', emailService.data).then(html => {
           output = html.trim().split('\n').map(line => line.trim());
-          done();
-        });
-      });
+        })
+      );
 
       it('contains both customer intro paragraphs', () => {
         config.customerIntro.forEach(paragraph => {
@@ -58,12 +55,11 @@ describe('HOF Emailer', () => {
 
     describe('Formatted Email', () => {
       let document;
-      beforeEach(done => {
+      beforeEach(() =>
         emailService._renderTemplate('formatted', 'customer', emailService.data).then(html => {
           document = parser.parseFromString(html, 'text/html');
-          done();
-        });
-      });
+        })
+      );
 
       describe('DocumentType', () => {
         let doctype;

--- a/test/unit/lib/email-service-spec.js
+++ b/test/unit/lib/email-service-spec.js
@@ -100,12 +100,11 @@ describe('Email Service', () => {
           emailService.sendEmails().should.be.an.instanceOf(Promise);
         });
 
-        it('resolves once sendEmail has resolved twice', done => {
+        it('resolves once sendEmail has resolved twice', () => {
           EmailService.prototype.sendEmail.returns(new Promise(resolve => resolve()));
-          emailService.sendEmails().then(() => {
-            EmailService.prototype.sendEmail.should.have.been.calledTwice;
-            done();
-          });
+          return emailService.sendEmails().then(() =>
+            EmailService.prototype.sendEmail.should.have.been.calledTwice
+          );
         });
       });
 
@@ -133,60 +132,53 @@ describe('Email Service', () => {
           emailService.sendEmail().should.be.an.instanceOf(Promise);
         });
 
-        it('calls _renderTemplate twice', done => {
-          emailService.sendEmail().then(() => {
-            EmailService.prototype._renderTemplate.should.have.been.calledTwice;
-            done();
-          });
-        });
+        it('calls _renderTemplate twice', () =>
+          emailService.sendEmail().then(() =>
+            EmailService.prototype._renderTemplate.should.have.been.calledTwice
+          )
+        );
 
-        it('calls emailer.sendEmail passing to address, customer subject and rendered templates', done => {
-          emailService.sendEmail('sterling@archer.com', 'customer').then(() => {
+        it('calls emailer.sendEmail passing to address, customer subject and rendered templates', () =>
+          emailService.sendEmail('sterling@archer.com', 'customer').then(() =>
             emailService.emailer.sendEmail.should.have.been.calledOnce
-              .and.calledWith('sterling@archer.com', 'A customer email', ['html', 'html']);
-            done();
-          });
-        });
+              .and.calledWith('sterling@archer.com', 'A customer email', ['html', 'html'])
+          )
+        );
 
-        it('calls emailer.sendEmail passing to address, caseworker subject and rendered templates', done => {
-          emailService.sendEmail('sterling@archer.com', 'caseworker').then(() => {
+        it('calls emailer.sendEmail passing to address, caseworker subject and rendered templates', () =>
+          emailService.sendEmail('sterling@archer.com', 'caseworker').then(() =>
             emailService.emailer.sendEmail.should.have.been.calledOnce
-              .and.calledWith('sterling@archer.com', 'A caseworker email', ['html', 'html']);
-            done();
-          });
-        });
+              .and.calledWith('sterling@archer.com', 'A caseworker email', ['html', 'html'])
+          )
+        );
 
-        it('logs to the console when an email is successfully sent', done => {
-          emailService.sendEmail('sterling@archer.com').then(() => {
-            console.info.should.have.been.calledWithExactly('Email sent');
-            done();
-          });
-        });
+        it('logs to the console when an email is successfully sent', () =>
+          emailService.sendEmail('sterling@archer.com').then(() =>
+            console.info.should.have.been.calledWithExactly('Email sent')
+          )
+        );
 
-        it('catches errors bubbled from emailer', done => {
+        it('catches errors bubbled from emailer', () => {
           emailService.emailer.sendEmail.yields(new Error('oops'));
-          emailService.sendEmail('sterling@archer.com').catch(err => {
-            err.should.be.an.instanceOf(Error);
-            done();
-          });
+          return emailService.sendEmail('sterling@archer.com').catch(err =>
+            err.should.be.an.instanceOf(Error)
+          );
         });
 
-        it('logs errors to the console', done => {
+        it('logs errors to the console', () => {
           const err = new Error('oops');
           emailService.emailer.sendEmail.yields(err);
-          emailService.sendEmail('sterling@archer.com').catch(() => {
-            console.error.should.have.been.calledWithExactly('Error sending email');
-            done();
-          });
+          return emailService.sendEmail('sterling@archer.com').catch(() =>
+            console.error.should.have.been.calledWithExactly('Error sending email')
+          );
         });
 
-        it('catches errors bubbled from _renderTemplate', done => {
+        it('catches errors bubbled from _renderTemplate', () => {
           const err = new Error('oops');
           EmailService.prototype._renderTemplate.returns(new Promise((resolve, reject) => reject(err)));
-          emailService.sendEmail('sterling@archer.com').catch(error => {
-            error.should.be.an.instanceOf(Error);
-            done();
-          });
+          return emailService.sendEmail('sterling@archer.com').catch(error =>
+            error.should.be.an.instanceOf(Error)
+          );
         });
       });
     });
@@ -320,40 +312,36 @@ describe('Email Service', () => {
           emailService._renderTemplate().should.be.an.instanceOf(Promise);
         });
 
-        it('calls the render method of the app', done => {
-          emailService._renderTemplate().then(() => {
-            emailService.app.render.should.have.been.calledOnce;
-            done();
-          });
-        });
+        it('calls the render method of the app', () =>
+          emailService._renderTemplate().then(() =>
+            emailService.app.render.should.have.been.calledOnce
+          )
+        );
 
-        it('passes template, recipient and data to the render method of the app', done => {
+        it('passes template, recipient and data to the render method of the app', () => {
           const dummyData = {};
-          emailService._renderTemplate('template', 'customer', dummyData).then(() => {
+          return emailService._renderTemplate('template', 'customer', dummyData).then(() =>
             emailService.app.render.should.have.been.calledWith('template', {
               data: dummyData,
               intro: undefined,
               outro: undefined,
               partials: undefined
-            });
-            done();
-          });
+            })
+          );
         });
 
-        it('resolves with html on successful calls', done => {
+        it('resolves with html on successful calls', () => {
           emailService.app.render.yields(null, '<div>html</div>');
-          emailService._renderTemplate().then(html => {
-            html.should.be.equal('<div>html</div>');
-            done();
-          });
+          return emailService._renderTemplate().then(html =>
+            html.should.be.equal('<div>html</div>')
+          );
         });
 
-        it('rejects with an error on unsuccessful calls', done => {
+        it('rejects with an error on unsuccessful calls', () => {
           emailService.app.render.yields(new Error('oops'));
-          emailService._renderTemplate().catch(err => {
-            err.should.be.an.instanceOf(Error);
-            done();
-          });
+          return emailService._renderTemplate().catch(err =>
+            err.should.be.an.instanceOf(Error)
+          );
         });
       });
     });

--- a/test/unit/lib/email-service-spec.js
+++ b/test/unit/lib/email-service-spec.js
@@ -66,6 +66,22 @@ describe('Email Service', () => {
       EmailService.prototype._includeDate.should.not.have.been.called;
     });
 
+    it('sets subject to email-service instance if passed object', () => {
+      const subject = {
+        customer: '',
+        caseworker: ''
+      };
+      emailService = new EmailService({data, subject});
+      emailService.subject.should.be.equal(subject);
+    });
+
+    it('sets customer and caseworker subject to email-service instance if passed string', () => {
+      const subject = 'a subject';
+      emailService = new EmailService({data, subject});
+      emailService.subject.customer.should.be.equal(subject);
+      emailService.subject.caseworker.should.be.equal(subject);
+    });
+
     describe('public methods', () => {
       beforeEach(() => {
         emailService = new EmailService({data});
@@ -95,7 +111,10 @@ describe('Email Service', () => {
 
       describe('sendEmail()', () => {
         beforeEach(() => {
-          emailService.subject = 'An Email';
+          emailService.subject = {
+            customer: 'A customer email',
+            caseworker: 'A caseworker email'
+          };
           emailService.emailer = {
             sendEmail: sinon.stub().yields(null, 'info')
           };
@@ -121,10 +140,18 @@ describe('Email Service', () => {
           });
         });
 
-        it('calls emailer.sendEmail passing to address, subject and rendered templates', done => {
-          emailService.sendEmail('sterling@archer.com').then(() => {
+        it('calls emailer.sendEmail passing to address, customer subject and rendered templates', done => {
+          emailService.sendEmail('sterling@archer.com', 'customer').then(() => {
             emailService.emailer.sendEmail.should.have.been.calledOnce
-              .and.calledWith('sterling@archer.com', 'An Email', ['html', 'html']);
+              .and.calledWith('sterling@archer.com', 'A customer email', ['html', 'html']);
+            done();
+          });
+        });
+
+        it('calls emailer.sendEmail passing to address, caseworker subject and rendered templates', done => {
+          emailService.sendEmail('sterling@archer.com', 'caseworker').then(() => {
+            emailService.emailer.sendEmail.should.have.been.calledOnce
+              .and.calledWith('sterling@archer.com', 'A caseworker email', ['html', 'html']);
             done();
           });
         });


### PR DESCRIPTION
This change allows you to pass either a string subject, which is used for both customer and caseworker, or an object with separate subjects for each:

```js
{
  customer: 'Customer subject',
  caseworker: 'Caseworker subject'
}
```