### PR TITLE
Email custom views

### DIFF
--- a/lib/email-service.js
+++ b/lib/email-service.js
@@ -14,6 +14,12 @@ module.exports = class EmailService {
       throw new Error('No options provided');
     }
 
+    this.viewsDir = [path.resolve(__dirname, ('../views'))];
+
+    if (options.customViews) {
+      this.viewsDir = [options.customViews].concat(this.viewsDir);
+    }
+
     this.emailerOptions = options;
 
     if (!options.data) {
@@ -46,9 +52,18 @@ module.exports = class EmailService {
   }
 
   sendEmails() {
-    let emails = [this.sendEmail(this.caseworkerEmail, 'caseworker', this.data)];
+    let emails = [];
+    if (this.caseworkerEmail) {
+      emails.push(this.sendEmail(this.caseworkerEmail, 'caseworker', this.data));
+    } else {
+      // eslint-disable-next-line no-console
+      console.info('No caseworker email set');
+    }
     if (this.customerEmail) {
       emails.push(this.sendEmail(this.customerEmail, 'customer', this.data));
+    } else {
+      // eslint-disable-next-line no-console
+      console.info('No customer email set');
     }
     return Promise.all(emails);
   }
@@ -76,7 +91,7 @@ module.exports = class EmailService {
   _initApp() {
     this.app = express();
     this.app.set('view engine', 'html');
-    this.app.set('views', path.resolve(__dirname, '../views'));
+    this.app.set('views', this.viewsDir);
     this.app.engine('html', hoganExpressStrict);
     this.app.enable('view cache');
     this.partials = traverse(this.app.get('views'));

--- a/test/unit/lib/email-service-spec.js
+++ b/test/unit/lib/email-service-spec.js
@@ -82,6 +82,12 @@ describe('Email Service', () => {
       emailService.subject.caseworker.should.be.equal(subject);
     });
 
+    it('sets the customViews to email-service instance if passed path string', () => {
+      const customViews = '/path/to/custom/views';
+      emailService = new EmailService({data, customViews});
+      emailService.viewsDir.should.have.length(2);
+    });
+
     describe('public methods', () => {
       beforeEach(() => {
         emailService = new EmailService({
@@ -114,7 +120,19 @@ describe('Email Service', () => {
         it('does not try to send an email to an undefined customer address', () => {
           emailService = new EmailService({
             data,
-            customerEmail: ''
+            customerEmail: '',
+            caseworker: 'caseworker@digital.homeoffice.gov.uk'
+          });
+          EmailService.prototype.sendEmail.returns(new Promise(resolve => resolve()));
+          return emailService.sendEmails().then(() =>
+            EmailService.prototype.sendEmail.should.have.been.calledOnce
+          );
+        });
+
+        it('does not try to send an email to an undefined caseworker address', () => {
+          emailService = new EmailService({
+            data,
+            customerEmail: 'customer@hotmail.com'
           });
           EmailService.prototype.sendEmail.returns(new Promise(resolve => resolve()));
           return emailService.sendEmails().then(() =>
@@ -234,7 +252,7 @@ describe('Email Service', () => {
         });
 
         it('sets the app view property to the views path', () => {
-          const viewsPath = path.resolve(__dirname, '../../../views');
+          const viewsPath = [path.resolve(__dirname, '../../../views')];
           emailService.app.set.secondCall.should.have.been.calledWithExactly('views', viewsPath);
         });
 


### PR DESCRIPTION
Added the ability to add custom templates for the email. If customViews exist use that directory otherwise use hof-emailers templates. 
Also added the ability to not have to set caseworker email.
Added tests for both