### PR TITLE
Allow emails to use full width of template

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -40,13 +40,12 @@
               </td>
             </tr>
             <tr>
-              <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <td style="font-family: Helvetica, Arial, sans-serif;">
                 <p style="font-weight: 700;font-size: 16px;line-height: 1 ;margin: 10px 0 10px 0;">&nbsp;</p>
               </td>
-              <td width="25%">&nbsp;</td>
             </tr>
             <tr>
-              <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <td style="font-family: Helvetica, Arial, sans-serif;">
                 <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">
                   {{subject}}
                 <p>


### PR DESCRIPTION
Restricting the body of the email content to 75% of the width leads to some really severe text wrapping. Instead allow the email content to use the full width.